### PR TITLE
fix: force protocol to lower case

### DIFF
--- a/src/components/convert.ts
+++ b/src/components/convert.ts
@@ -58,7 +58,7 @@ const encryptUrl = (url: string) => {
 
   for (const proto of knownProto) {
     const protoLength = proto.length + 3
-    if (url.substring(0, protoLength) === proto + '://') {
+    if (url.substring(0, protoLength).toLowerCase() === proto + '://') {
       protocol = proto
       url = url.substr(protoLength)
       break


### PR DESCRIPTION
Happy new year! This patch is to make sure cases like `Http://v.zaibit.com/` (manually entered URL uppercased by IME) still get converted correctly in webvpn.